### PR TITLE
Feat: add Tooltip component with CSS Anchor Positioning

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -36,7 +36,7 @@ const Modal = ({ isOpened, close, children, ...props }: Props) => {
         className
       )}
     >
-      {children}
+      {isOpened && children}
     </dialog>
   )
 }

--- a/src/components/TokenDebugPanel/components/CopyButton.tsx
+++ b/src/components/TokenDebugPanel/components/CopyButton.tsx
@@ -1,4 +1,5 @@
 import Icon, { IconsNames } from '@/components/Icon'
+import Tooltip from '@/components/Tooltip'
 import { useState } from 'react'
 
 type Props = {
@@ -30,9 +31,11 @@ const CopyButton = ({ text }: Props) => {
   const { icon, color, title } = statusStyles[status]
 
   return (
-    <button type='button' onClick={handleCopy} className='rounded p-1 hover:bg-gray-200' title={title} aria-label={title}>
-      <Icon name={icon} className={`h-4 w-4 ${color}`} />
-    </button>
+    <Tooltip content={title}>
+      <button type='button' onClick={handleCopy} className='rounded p-1 hover:bg-gray-200' aria-label={title}>
+        <Icon name={icon} className={`h-4 w-4 ${color}`} />
+      </button>
+    </Tooltip>
   )
 }
 

--- a/src/components/TokenDebugPanel/components/JwtLink.tsx
+++ b/src/components/TokenDebugPanel/components/JwtLink.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/components/Icon'
+import Tooltip from '@/components/Tooltip'
 
 type Props = {
   token: string
@@ -8,16 +9,17 @@ const JwtLink = ({ token }: Props) => {
   const jwtDebuggerUrl = `https://jwt.io/#debugger-io?token=${encodeURIComponent(token)}`
 
   return (
-    <a
-      href={jwtDebuggerUrl}
-      target='_blank'
-      rel='noopener noreferrer'
-      className='rounded p-1 hover:bg-gray-200'
-      title='Ver en jwt.io'
-      aria-label='Ver en jwt.io'
-    >
-      <Icon name='Jwt' className='h-4 w-4' />
-    </a>
+    <Tooltip content='Ver en jwt.io' position='top'>
+      <a
+        href={jwtDebuggerUrl}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='rounded p-1 hover:bg-gray-200'
+        aria-label='Ver en jwt.io'
+      >
+        <Icon name='Jwt' className='h-4 w-4' />
+      </a>
+    </Tooltip>
   )
 }
 

--- a/src/components/TokenDebugPanel/index.tsx
+++ b/src/components/TokenDebugPanel/index.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/Button'
 import Icon from '@/components/Icon'
+import Tooltip from '@/components/Tooltip'
 import { getTokens, subscribeToTokens, refreshAccessToken } from '@/service/token-service'
 import { getTokenPayload } from '@/utils/jwt'
 import { useState, useSyncExternalStore } from 'react'
@@ -35,16 +36,17 @@ const TokenDebugPanel = () => {
   return (
     <div className='fixed bottom-4 left-4 z-50'>
       {/* FAB Button */}
-      <button
-        type='button'
-        onClick={() => setIsOpen(!isOpen)}
-        className={`flex h-12 cursor-pointer items-center justify-center gap-2 rounded-full px-4 text-white shadow-lg transition-all duration-300 ease-in-out hover:scale-105 ${statusButtonColor[getProgressStatus(progress)]}`}
-        style={expired ? { animation: 'soft-pulse 1.8s ease-out infinite' } : undefined}
-        title='Token Debug Panel'
-      >
-        <Icon name='InfoCircle' className='h-6 w-6 fill-white' />
-        <span className='whitespace-nowrap font-mono text-sm font-medium'>{expired ? '0:00' : timeRemaining}</span>
-      </button>
+      <Tooltip content='Token Debug Panel' position='right'>
+        <button
+          type='button'
+          onClick={() => setIsOpen(!isOpen)}
+          className={`flex h-12 cursor-pointer items-center justify-center gap-2 rounded-full px-4 text-white shadow-lg transition-all duration-300 ease-in-out hover:scale-105 ${statusButtonColor[getProgressStatus(progress)]}`}
+          style={expired ? { animation: 'soft-pulse 1.8s ease-out infinite' } : undefined}
+        >
+          <Icon name='InfoCircle' className='h-6 w-6 fill-white' />
+          <span className='whitespace-nowrap font-mono text-sm font-medium'>{expired ? '0:00' : timeRemaining}</span>
+        </button>
+      </Tooltip>
 
       {/* Panel */}
       {isOpen && (
@@ -52,15 +54,16 @@ const TokenDebugPanel = () => {
           {/* Header */}
           <div className='flex items-center justify-between bg-primary-700 px-4 py-3'>
             <span className='text-sm font-semibold text-white'>Token Debug</span>
-            <button
-              type='button'
-              onClick={() => setIsOpen(false)}
-              className='flex h-5 w-5 items-center justify-center text-xl font-bold leading-none text-white/80 hover:text-white'
-              title='Minimizar'
-              aria-label='Minimizar panel de debug'
-            >
-              −
-            </button>
+            <Tooltip content='Minimizar' position='left'>
+              <button
+                type='button'
+                onClick={() => setIsOpen(false)}
+                className='flex h-5 w-5 items-center justify-center text-xl font-bold leading-none text-white/80 hover:text-white'
+                aria-label='Minimizar panel de debug'
+              >
+                −
+              </button>
+            </Tooltip>
           </div>
 
           {/* Content */}
@@ -71,12 +74,14 @@ const TokenDebugPanel = () => {
                 <span className='text-sm font-medium text-primary-700'>Refresh Token</span>
                 <div className='flex items-center gap-2'>
                   {refreshCount > 0 && (
-                    <span
-                      className='rounded-full bg-accent-100 px-2 py-0.5 text-xs text-accent-700'
-                      title={`Token refrescado ${refreshCount} ${refreshCount === 1 ? 'vez' : 'veces'} en esta sesión`}
+                    <Tooltip
+                      content={`Token refrescado ${refreshCount} ${refreshCount === 1 ? 'vez' : 'veces'} en esta sesión`}
+                      position='left'
                     >
-                      {refreshCount}x
-                    </span>
+                      <span className='rounded-full bg-accent-100 px-2 py-0.5 text-xs text-accent-700'>
+                        {refreshCount}x
+                      </span>
+                    </Tooltip>
                   )}
                   <Icon name='CheckOutlineThin' className='h-5 w-5 fill-green-500' />
                 </div>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, CSSProperties, isValidElement, useId } from 'react'
+import { cloneElement, isValidElement, useId } from 'react'
 import { twMerge } from 'tailwind-merge'
 import './tooltip.css'
 
@@ -49,9 +49,10 @@ const Tooltip = ({ content, position = 'top', tooltipClassName, children }: Prop
     )
   }
 
-  const childrenWithAnchorName = isValidElement<{ style?: CSSProperties }>(children)
+  const childrenWithAnchorName = isValidElement<React.HTMLAttributes<HTMLElement>>(children)
     ? cloneElement(children, {
         style: { ...children.props.style, anchorName },
+        'aria-describedby': anchorName,
       })
     : children
 
@@ -59,6 +60,7 @@ const Tooltip = ({ content, position = 'top', tooltipClassName, children }: Prop
     <>
       <span className='tooltip-trigger'>{childrenWithAnchorName}</span>
       <span
+        id={anchorName}
         role='tooltip'
         className={twMerge('tooltip-content', `tooltip-${position}`, tooltipClassName)}
         style={{ positionAnchor: anchorName }}

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,0 +1,72 @@
+import { cloneElement, CSSProperties, isValidElement, useId } from 'react'
+import { twMerge } from 'tailwind-merge'
+import './tooltip.css'
+
+type TooltipPosition = 'top' | 'bottom' | 'left' | 'right'
+
+type Props = {
+  content: React.ReactNode
+  position?: TooltipPosition
+  tooltipClassName?: string
+  children: React.ReactNode
+}
+
+const supportsAnchorPositioning = typeof CSS !== 'undefined' && CSS.supports('anchor-name: --test')
+
+// Safari tiene problemas con anchor positioning combinado con display: contents
+const isSafari = typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
+const isAnchorPositioningSupported = supportsAnchorPositioning && !isSafari
+
+/**
+ * Tooltip con CSS Anchor Positioning
+ *
+ * Limitaciones conocidas:
+ * - Asume que children renderiza un elemento DOM (no texto plano ni fragments)
+ * - En browsers sin soporte suficiente de anchor positioning, usa `title` nativo como fallback
+ * - Safari se excluye explícitamente por problemas observados con esta implementación
+ * - Optimizado para browsers modernos
+ */
+const Tooltip = ({ content, position = 'top', tooltipClassName, children }: Props) => {
+  const uniqueId = useId()
+
+  const sanitizedId = uniqueId.replace(/:/g, '')
+  const anchorName = `--tooltip-${sanitizedId}`
+
+  const isStringContent = typeof content === 'string' && content !== ''
+
+  const shouldRenderTooltip = isStringContent || (isValidElement(content) && isAnchorPositioningSupported)
+
+  if (!shouldRenderTooltip) {
+    return <>{children}</>
+  }
+
+  if (isStringContent && !isAnchorPositioningSupported) {
+    return (
+      <span className='tooltip-trigger' title={content}>
+        {children}
+      </span>
+    )
+  }
+
+  const childrenWithAnchorName = isValidElement<{ style?: CSSProperties }>(children)
+    ? cloneElement(children, {
+        style: { ...children.props.style, anchorName },
+      })
+    : children
+
+  return (
+    <>
+      <span className='tooltip-trigger'>{childrenWithAnchorName}</span>
+      <span
+        role='tooltip'
+        className={twMerge('tooltip-content', `tooltip-${position}`, tooltipClassName)}
+        style={{ positionAnchor: anchorName }}
+      >
+        {content}
+      </span>
+    </>
+  )
+}
+
+export default Tooltip

--- a/src/components/Tooltip/tooltip.css
+++ b/src/components/Tooltip/tooltip.css
@@ -1,0 +1,58 @@
+.tooltip-trigger {
+  display: contents;
+}
+
+.tooltip-content {
+  position: fixed;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  background-color: var(--color-primary-800);
+  color: white;
+  font-size: 0.75rem;
+  white-space: normal;
+  max-width: 20rem;
+  width: max-content;
+  text-wrap: balance;
+  z-index: 50;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(0.96);
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+  position-visibility: anchors-visible;
+  position-try-fallbacks: flip-block, flip-inline;
+}
+
+.tooltip-trigger:hover + .tooltip-content,
+.tooltip-trigger:has(:focus-visible) + .tooltip-content {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1);
+}
+
+/* Posiciones con position-area y animación direccional */
+.tooltip-top {
+  position-area: top;
+  margin-bottom: 0.5rem;
+  transform: translateY(4px) scale(0.96);
+}
+
+.tooltip-bottom {
+  position-area: bottom;
+  margin-top: 0.5rem;
+  transform: translateY(-4px) scale(0.96);
+}
+
+.tooltip-left {
+  position-area: left;
+  margin-right: 0.5rem;
+  transform: translateX(4px) scale(0.96);
+}
+
+.tooltip-right {
+  position-area: right;
+  margin-left: 0.5rem;
+  transform: translateX(-4px) scale(0.96);
+}

--- a/src/views/EditarHeladeria/components/EditarGustos/components/AgregarGustosModal/index.tsx
+++ b/src/views/EditarHeladeria/components/EditarGustos/components/AgregarGustosModal/index.tsx
@@ -2,6 +2,7 @@ import Button from '@/components/Button'
 import Input from '@/components/Input'
 import Label from '@/components/Label'
 import Modal from '@/components/Modal'
+import Tooltip from '@/components/Tooltip'
 import ModalTitle from '@/components/Modal/components/ModalTitle'
 import { Heladeria } from '@/model/heladeria'
 import { useState } from 'react'
@@ -57,9 +58,11 @@ const AgregarGustoModal = ({ isOpened, heladeria, setHeladeria, close }: Props) 
             max={10}
             step={1}
             label={
-              <Label title='Un número entre 1 y 10' className='flex items-center gap-1' htmlFor='dificultadGusto'>
-                Dificultad
-              </Label>
+              <Tooltip content='Un número entre 1 y 10' position='right'>
+                <Label className='flex w-fit items-center gap-1' htmlFor='dificultadGusto'>
+                  Dificultad
+                </Label>
+              </Tooltip>
             }
             value={nuevoGusto.dificultad || ''}
             onChange={(e) =>
@@ -72,7 +75,15 @@ const AgregarGustoModal = ({ isOpened, heladeria, setHeladeria, close }: Props) 
 
         <section className='mt-1 flex w-full gap-3'>
           <Button type='button' className='button-outlined flex-1' label='Cancelar' onClick={onClose} />
-          <Button type='button' label='Agregar' title={error} className='button-primary flex-1' disabled={!!error} onClick={agregarGusto} />
+          <Tooltip content={error} position='right'>
+            <Button
+              type='button'
+              label='Agregar'
+              className='button-primary flex-1'
+              disabled={!!error}
+              onClick={agregarGusto}
+            />
+          </Tooltip>
         </section>
       </div>
     </Modal>

--- a/src/views/Home/components/BuscarHeladerias/index.tsx
+++ b/src/views/Home/components/BuscarHeladerias/index.tsx
@@ -38,7 +38,6 @@ const BuscarHeladerias = ({ valorInicial = '', onSearch }: Props) => {
       />
       <Button
         className='button-primary min-w-[10rem]'
-        title='Buscar heladerías'
         label={
           <>
             <Icon className='h-5 fill-white' name={'Search'} />

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,8 +1,8 @@
 import Card from '@/components/Card'
+import Icon from '@/components/Icon'
 import { useLoaderData, useNavigate, useSearch } from '@tanstack/react-router'
 import BuscarHeladerias from './components/BuscarHeladerias'
 import TablaHeladerias from './components/TablaHeladerias'
-import Icon from '@/components/Icon'
 import { clearTokens, getPrimaryRole } from '@/service/token-service'
 
 const Home = () => {
@@ -44,7 +44,6 @@ const Home = () => {
         <button
           type='button'
           onClick={logout}
-          title='Salir de la aplicación'
           className='group inline-flex items-center gap-2 self-start rounded-lg border border-primary-200 bg-white/85 px-3 py-2 text-sm text-primary-600 transition-colors hover:border-error-200 hover:bg-error-50 hover:text-error-600'
         >
           <Icon name='Power' className='h-4 fill-primary-500 group-hover:fill-error-600' />

--- a/src/views/Login/index.tsx
+++ b/src/views/Login/index.tsx
@@ -60,7 +60,6 @@ export const Login = () => {
             <Button
               type='submit'
               className='button-primary mt-2 w-full'
-              title='Ingresar al sistema'
               label='Ingresar'
               disabled={!usuario || !password}
             />


### PR DESCRIPTION
Hola! acá un nuevo PR que agrega un componente custom de Tooltip:
  - Implementado con [Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning). Es una feature relativamente nueva de CSS con buen [soporte](https://caniuse.com/css-anchor-positioning)
  - Fallback a title nativo en browsers sin soporte (y en Safari que dice soportarlo pero tiene bugs conocidos)
  - Soporta 4 posiciones: top, bottom, left, right (con flip automático si no hay espacio)
  
<img width="2160" height="1186" alt="image" src="https://github.com/user-attachments/assets/26d9dbe3-df64-46b7-950a-4132090c61bb" />
<img width="2160" height="1186" alt="image" src="https://github.com/user-attachments/assets/afbee92a-aabd-438b-9826-472b673442a1" />
<img width="2160" height="1186" alt="image" src="https://github.com/user-attachments/assets/8a966a13-a4b2-467a-9d54-f74d689c361d" />
